### PR TITLE
Remove setAppCacheEnabled

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -245,13 +245,10 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     if (enabled) {
       Context ctx = view.getContext();
       if (ctx != null) {
-        view.getSettings().setAppCachePath(ctx.getCacheDir().getAbsolutePath());
         view.getSettings().setCacheMode(WebSettings.LOAD_DEFAULT);
-        view.getSettings().setAppCacheEnabled(true);
       }
     } else {
       view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-      view.getSettings().setAppCacheEnabled(false);
     }
   }
 
@@ -376,7 +373,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     // Disable caching
     view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-    view.getSettings().setAppCacheEnabled(!enabled);
     view.clearHistory();
     view.clearCache(enabled);
 


### PR DESCRIPTION
If applied this commit will prune the `setAppCacheEnabled` to make library compatible with Android target SDK level 33

* Partially Solves https://github.com/aiincorporated/bobMobileAppAndroid/issues/1242
* Prune deprecated `setAppCacheEnabled`  from the code, `setAppCacheEnabled` enables/disables application cache API As the application cache api is depreceated this method is no longer supported. https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/webkit/WebSettings.java#1171